### PR TITLE
fix: panic when no input

### DIFF
--- a/main.go
+++ b/main.go
@@ -121,7 +121,11 @@ func main() {
 
 	input = cut(input, config.Lines)
 	if input == "" {
-		printErrorFatal("No input", errors.New("check that the input isn't empty, and that --lines is within its bounds"))
+		if err != nil {
+			printErrorFatal("No input", err)
+		} else {
+			printErrorFatal("No input", errors.New("check --lines is within bounds"))
+		}
 	}
 
 	s, ok := styles.Registry[strings.ToLower(config.Theme)]


### PR DESCRIPTION
Fixes the following panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xacbe0d]

goroutine 1 [running]:
main.printError({0xba8388, 0x8}, {0x0, 0x0})
        /home/carlos/Developer/charmbracelet/freeze/error.go:15 +0x10d
main.printErrorFatal({0xba8388?, 0xc00039ec7e?}, {0x0?, 0x0?})
        /home/carlos/Developer/charmbracelet/freeze/error.go:19 +0x25
main.main()
        /home/carlos/Developer/charmbracelet/freeze/main.go:123 +0xaab
```