### PR TITLE
fix: better handle tty's when -o is set

### DIFF
--- a/main.go
+++ b/main.go
@@ -309,10 +309,10 @@ func main() {
 		}
 
 	default:
-		if config.Output == "" && len(ctx.Args) > 0 {
+		if config.Output == "" && len(ctx.Args) > 0 && istty {
 			config.Output = strings.TrimSuffix(filepath.Base(ctx.Args[0]), filepath.Ext(ctx.Args[0])) + ".svg"
 		}
-		if istty {
+		if config.Output != "" {
 			err = doc.WriteToFile(config.Output)
 		} else {
 			_, err = doc.WriteTo(os.Stdout)


### PR DESCRIPTION
Currently, if -o is set to svg, but term is not a tty, it would write to stdout - which was unexpected.