### PR TITLE
fix: do not name output -.svg

### DIFF
--- a/main.go
+++ b/main.go
@@ -310,8 +310,8 @@ func main() {
 		}
 
 	default:
-		if config.Output == "" {
-			if len(ctx.Args) > 0 && ctx.Args[0] != "-" && istty {
+		if config.Output == "" && istty {
+			if len(ctx.Args) > 0 && ctx.Args[0] != "-" {
 				config.Output = strings.TrimSuffix(filepath.Base(ctx.Args[0]), filepath.Ext(ctx.Args[0])) + ".svg"
 			} else {
 				config.Output = "out.svg"


### PR DESCRIPTION
if input is `-`, it would create a `-.svg`, which is tricky to delete, as `rm` will try to parse `.` as a flag (`rm -- -.svg` avoids it btw) 