### PR TITLE
chore: add format option instead of always deriving from extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 !test/golden/**/*.png
 !examples/*.svg
 /result
+freeze

--- a/config.go
+++ b/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	Theme       string `json:"theme" help:"Theme to use for syntax highlighting." short:"t" group:"Settings" placeholder:"charm"`
 
 	Output         string        `json:"output,omitempty" help:"Output location for {{.svg}}, {{.png}}, or {{.webp}}." short:"o" group:"Settings" default:"" placeholder:"freeze.svg"`
+	Format         string        `json:"format,omitempty" help:"Output format for file, {{.svg}}, {{.png}} or {{.webp}}." short:"f" group:"Settings" default:"svg" placeholder:"svc"`
 	Execute        string        `json:"-" help:"Capture output of command execution." short:"x" group:"Settings" default:""`
 	ExecuteTimeout time.Duration `json:"-" help:"Execution timeout." group:"Settings" default:"10s" prefix:"execute." name:"timeout" hidden:""`
 

--- a/main.go
+++ b/main.go
@@ -388,8 +388,17 @@ func main() {
 
 	istty := isatty.IsTerminal(os.Stdout.Fd())
 
-	switch {
-	case strings.HasSuffix(config.Output, ".png"):
+	var format string
+
+	if config.Format != "" {
+		format = config.Format
+	} else {
+		parts := strings.Split(config.Output, ".")
+		format = parts[len(parts)-1]
+	}
+
+	switch format {
+	case "png":
 		// use libsvg conversion.
 		svgConversionErr := libsvgConvert(doc, imageWidth, imageHeight, config.Output)
 		if svgConversionErr == nil {


### PR DESCRIPTION
this is needed for when we want to write image to a pipe or socket and I can't just name it `blabla.png`. 

this should fall back on using extension like before if format isn't specified.

treats the format also the same way it did before with extension. logic isn't touched.