### PR TITLE
Fix arch linux installation guide in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Freeze is also [super customizable](#customization) and ships with an [interacti
 # macOS or Linux
 brew install charmbracelet/tap/freeze
 
-# Arch Linux (btw)
-pacman -S freeze
+# Arch Linux AUR (btw)
+yay -S freeze # or paru -S freeze
 
 # Nix
 nix-env -iA nixpkgs.charm-freeze

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Freeze is also [super customizable](#customization) and ships with an [interacti
 # macOS or Linux
 brew install charmbracelet/tap/freeze
 
-# Arch Linux AUR (btw)
-yay -S freeze # or paru -S freeze
+# Arch Linux (btw)
+yay -S freeze
 
 # Nix
 nix-env -iA nixpkgs.charm-freeze


### PR DESCRIPTION
freeze is currently in AUR only, thus change `pacman` to `yay` or `paru`.