### PR TITLE
feat(#95): added `freeze` version flag

### DIFF
--- a/config.go
+++ b/config.go
@@ -27,6 +27,7 @@ type Config struct {
 
 	// Settings
 	Config      string `json:"config,omitempty" help:"Base configuration file or template." short:"c" group:"Settings" default:"default" placeholder:"base"`
+	Version     bool   `hidden:"" json:",omitempty" help:"Show version and exit." short:"v" group:"Settings"`
 	Interactive bool   `hidden:"" json:",omitempty" help:"Use an interactive form for configuration options." short:"i" group:"Settings"`
 	Language    string `json:"language,omitempty" help:"Language of code file." short:"l" group:"Settings" placeholder:"go"`
 	Theme       string `json:"theme" help:"Theme to use for syntax highlighting." short:"t" group:"Settings" placeholder:"charm"`

--- a/help.go
+++ b/help.go
@@ -41,7 +41,7 @@ func helpPrinter(_ kong.HelpOptions, ctx *kong.Context) error {
 
 	fmt.Println()
 	for _, f := range flags {
-		if f.Name == "interactive" {
+		if f.Name == "version" || f.Name == "interactive" {
 			printFlag(f)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -60,25 +60,20 @@ func main() {
 		printErrorFatal("Invalid Usage", err)
 	}
 
-	if len(ctx.Args) > 0 {
-		switch ctx.Args[0] {
-
-		case "version":
-			if Version == "" {
-				if info, ok := debug.ReadBuildInfo(); ok && info.Main.Sum != "" {
-					Version = info.Main.Version
-				} else {
-					Version = "unknown (built from source)"
-				}
+	if config.Version {
+		if Version == "" {
+			if info, ok := debug.ReadBuildInfo(); ok && (info.Main.Version != "" && info.Main.Version != "(devel)") {
+				Version = info.Main.Version
+			} else {
+				Version = "latest (built from source)"
 			}
-			version := fmt.Sprintf("freeze version %s", Version)
-			if len(CommitSHA) >= shaLen {
-				version += " (" + CommitSHA[:shaLen] + ")"
-			}
-
-			fmt.Println(version)
-			os.Exit(0)
 		}
+		version := fmt.Sprintf("freeze version: %s", Version)
+		if len(CommitSHA) > 7 {
+			version += fmt.Sprintf(" (%s)", CommitSHA[:shaLen])
+		}
+		fmt.Println(version)
+		os.Exit(0)
 	}
 
 	// Copy the pty output to buffer


### PR DESCRIPTION
Using `freeze --version` or `freeze -v` shows the current version, `latest (built from source)` if `go install github.com/charmbracelet/freeze@latest`.

![image from `freeze -v`](https://github.com/charmbracelet/freeze/assets/71392160/dddd4757-74be-4031-a4e8-a54487c1e76e)

> [!NOTE]
> Image after using `freeze --execute "./freeze -v"`

- Test passed with `make test` and `go test -v ./...` on **MacOS 14.5 (23F79)**

![image from `go test -v ./...`](https://github.com/charmbracelet/freeze/assets/71392160/0c76c8ca-e6f2-413c-ae28-a30ed72f4b4a)

> [!NOTE]
> Image after using `freeze --execute "go test -v ./..."`

Closes #95.