### PR TITLE
feat(#58): write to stdout if not `tty`

### DIFF
--- a/main.go
+++ b/main.go
@@ -409,7 +409,9 @@ func main() {
 		if svgConversionErr != nil {
 			printErrorFatal("Unable to convert SVG to PNG", svgConversionErr)
 		}
-		printFilenameOutput(config.Output)
+		if istty {
+			printFilenameOutput(config.Output)
+		}
 
 	default:
 		// output file specified.

--- a/png.go
+++ b/png.go
@@ -9,7 +9,10 @@ import (
 	"github.com/beevik/etree"
 	"github.com/charmbracelet/freeze/font"
 	"github.com/kanrichan/resvg-go"
+	"github.com/mattn/go-isatty"
 )
+
+var istty = isatty.IsTerminal(os.Stdout.Fd())
 
 func libsvgConvert(doc *etree.Document, w, h float64, output string) error {
 	_, err := exec.LookPath("rsvg-convert")
@@ -27,6 +30,9 @@ func libsvgConvert(doc *etree.Document, w, h float64, output string) error {
 	rsvgConvert := exec.Command("rsvg-convert", "-o", output)
 	rsvgConvert.Stdin = bytes.NewReader(svg)
 	err = rsvgConvert.Run()
+	if !istty {
+		_, err = doc.WriteTo(os.Stdout)
+	}
 	return err
 }
 
@@ -93,6 +99,9 @@ func resvgConvert(doc *etree.Document, w, h float64, output string) error {
 	err = os.WriteFile(output, png, 0644)
 	if err != nil {
 		return err
+	}
+	if !istty {
+		_, err = doc.WriteTo(os.Stdout)
 	}
 	return err
 }


### PR DESCRIPTION
When piping the command like `freeze png.go | pbcopy` it will write to the `stdout`.

Like @maaslalani said, when not `tty` it will write to `stdout`.
- https://github.com/charmbracelet/freeze/pull/97#issuecomment-2142953257

## Demo

https://github.com/charmbracelet/freeze/assets/71392160/c7e93918-10d8-4862-bba8-3cd9949a2d5a