### PR TITLE
chore(nix): update default.nix with new vendorHash

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,5 +2,5 @@
 pkgs.buildGoModule {
   name = "freeze";
   src = ./.;
-  vendorHash = "sha256-AUFzxmQOb/h0UgcprY09IVI7Auitn3JTDU/ptKicIAU=";
+  vendorHash = "sha256-OFNpZ6BOxC1nVmf0X89wlzIb3S7xS89YX4EkYXF4ozM=";
 }


### PR DESCRIPTION
This fixes an issue I encountered where this would not build on Nix systems due to the vendorHash being out of date. This was done by removing the old hash, running a build, and adding the new vendorHash.