### PR TITLE
fix: ANSI background colors not rendered correctly

### DIFF
--- a/ansi.go
+++ b/ansi.go
@@ -180,8 +180,8 @@ func (p *dispatcher) CsiDispatch(s ansi.CsiSequence) {
 				p.beginBackground(fill)
 				i += 3
 			}
-		case 100, 101, 102, 103, 104, 105, 106, 107:
-			p.beginBackground(ansiPalette[v])
+		case 40, 41, 42, 43, 44, 45, 46, 47, 100, 101, 102, 103, 104, 105, 106, 107:
+			p.beginBackground(ansiPalette[v-10])
 		}
 		i++
 	}


### PR DESCRIPTION
Currently, ANSI background colors are rendered as either gray or black since the fill is not correctly selected. This PR makes the correct color get chosen.

Before:
![Example of current behavior](https://github.com/user-attachments/assets/5da58f4f-09dd-4949-8e36-7543b26ac10b)

After:
![Example with fixed background colors](https://github.com/user-attachments/assets/b805c115-7766-4ddc-bb23-68dd6eb08c40)

I generated the previews with [gabe565/print-xterm256-go](https://github.com/gabe565/print-xterm256-go) if you want to test this change.
