### PR TITLE
fix: Support bold ANSI escape sequence

### DIFF
--- a/ansi.go
+++ b/ansi.go
@@ -138,7 +138,7 @@ func (p *dispatcher) CsiDispatch(s ansi.CsiSequence) {
 		case 0:
 			reset()
 		case 1:
-			// span.CreateAttr("font-weight", "bold")
+			span.CreateAttr("font-weight", "bold")
 			p.lines[p.row].AddChild(span)
 		case 9:
 			span.CreateAttr("text-decoration", "line-through")


### PR DESCRIPTION
The code to print bold text is currently commented out, even though it works fine. This PR uncomments it to add support for rendering bold text.

Fixes #75 