### PR TITLE
feat(#184): Add a `--version` flag and remove the `version` command

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,7 +26,7 @@ type Config struct {
 	Height     float64   `json:"height" help:"Height of terminal window." short:"H" group:"Window"`
 
 	// Settings
-	Version     bool   `json:"version" help:"Freeze version" short:"v" group:"Settings" `
+	Version     bool   `json:"version" help:"Display Freeze version." short:"v" group:"Settings"`
 	Config      string `json:"config,omitempty" help:"Base configuration file or template." short:"c" group:"Settings" default:"default" placeholder:"base"`
 	Interactive bool   `hidden:"" json:",omitempty" help:"Use an interactive form for configuration options." short:"i" group:"Settings"`
 	Language    string `json:"language,omitempty" help:"Language of code file." short:"l" group:"Settings" placeholder:"go"`

--- a/config.go
+++ b/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	Height     float64   `json:"height" help:"Height of terminal window." short:"H" group:"Window"`
 
 	// Settings
+	Version     bool   `json:"version" help:"Freeze version" short:"v" group:"Settings" `
 	Config      string `json:"config,omitempty" help:"Base configuration file or template." short:"c" group:"Settings" default:"default" placeholder:"base"`
 	Interactive bool   `hidden:"" json:",omitempty" help:"Use an interactive form for configuration options." short:"i" group:"Settings"`
 	Language    string `json:"language,omitempty" help:"Language of code file." short:"l" group:"Settings" placeholder:"go"`

--- a/config.go
+++ b/config.go
@@ -26,7 +26,7 @@ type Config struct {
 	Height     float64   `json:"height" help:"Height of terminal window." short:"H" group:"Window"`
 
 	// Settings
-	Version     bool   `json:"version" help:"Display Freeze version." short:"v" group:"Settings"`
+	Version     bool   `json:"version" help:"Display Freeze's version." short:"v" group:"Settings"`
 	Config      string `json:"config,omitempty" help:"Base configuration file or template." short:"c" group:"Settings" default:"default" placeholder:"base"`
 	Interactive bool   `hidden:"" json:",omitempty" help:"Use an interactive form for configuration options." short:"i" group:"Settings"`
 	Language    string `json:"language,omitempty" help:"Language of code file." short:"l" group:"Settings" placeholder:"go"`

--- a/main.go
+++ b/main.go
@@ -15,14 +15,15 @@ import (
 	"github.com/alecthomas/chroma/v2/styles"
 	"github.com/alecthomas/kong"
 	"github.com/beevik/etree"
-	in "github.com/charmbracelet/freeze/input"
-	"github.com/charmbracelet/freeze/svg"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/log"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/ansi/parser"
 	"github.com/mattn/go-isatty"
 	"github.com/muesli/reflow/wordwrap"
+
+	in "github.com/charmbracelet/freeze/input"
+	"github.com/charmbracelet/freeze/svg"
 )
 
 const (
@@ -60,25 +61,20 @@ func main() {
 		printErrorFatal("Invalid Usage", err)
 	}
 
-	//nolint: nestif
-	if len(ctx.Args) > 0 {
-		switch ctx.Args[0] {
-		case "version":
-			if Version == "" {
-				if info, ok := debug.ReadBuildInfo(); ok && info.Main.Sum != "" {
-					Version = info.Main.Version
-				} else {
-					Version = "unknown (built from source)"
-				}
+	if config.Version {
+		if Version == "" {
+			if info, ok := debug.ReadBuildInfo(); ok && info.Main.Sum != "" {
+				Version = info.Main.Version
+			} else {
+				Version = "unknown (built from source)"
 			}
-			version := fmt.Sprintf("freeze version %s", Version)
-			if len(CommitSHA) >= shaLen {
-				version += " (" + CommitSHA[:shaLen] + ")"
-			}
-
-			fmt.Println(version)
-			os.Exit(0)
 		}
+		version := fmt.Sprintf("freeze version %s", Version)
+		if len(CommitSHA) >= shaLen {
+			version += " (" + CommitSHA[:shaLen] + ")"
+		}
+		fmt.Println(version)
+		os.Exit(0)
 	}
 
 	// Copy the pty output to buffer

--- a/main.go
+++ b/main.go
@@ -62,12 +62,11 @@ func main() {
 	}
 
 	if config.Version {
-		if Version == "" {
-			if info, ok := debug.ReadBuildInfo(); ok && info.Main.Sum != "" {
-				Version = info.Main.Version
-			} else {
-				Version = "unknown (built from source)"
-			}
+		info, ok := debug.ReadBuildInfo()
+		if Version == "" && ok && info.Main.Sum != "" {
+			Version = info.Main.Version
+		} else {
+			Version = "unknown (built from source)"
 		}
 		version := fmt.Sprintf("freeze version %s", Version)
 		if len(CommitSHA) >= shaLen {


### PR DESCRIPTION
Adds support for the `--version` (or `-v`) flag and removes the previously implemented `version` command.

Related to [#184](https://github.com/charmbracelet/freeze/issues/184).