### PR TITLE
fix(ansi): CSI sequences giving index out of range

### DIFF
--- a/ansi.go
+++ b/ansi.go
@@ -110,7 +110,9 @@ func (p *dispatcher) CsiDispatch(cmd ansi.Cmd, params ansi.Params) {
 		// reset ANSI, this is done by creating a new empty tspan,
 		// which would reset all the styles such that when text is appended to the last
 		// child of this line there is no styling applied.
-		p.lines[p.row].AddChild(span)
+		if p.row < len(p.lines) {
+			p.lines[p.row].AddChild(span)
+		}
 		p.endBackground()
 	}
 

--- a/freeze_test.go
+++ b/freeze_test.go
@@ -136,10 +136,6 @@ func TestFreezeConfigurations(t *testing.T) {
 			flags:  []string{"--language", "go", "--height", "800", "--width", "750", "--config", "full", "--window=false", "--show-line-numbers"},
 			output: "bubbletea",
 		},
-		// {
-		// 	flags:  []string{"--execute", "layout", "--height", "800", "--config", "full", "--margin", "50,10"},
-		// 	output: "composite-2",
-		// },
 		{
 			input:  "test/input/layout.ansi",
 			flags:  []string{},


### PR DESCRIPTION
- **fix(ansi): fix index out of bounds when CSI sequences exist**
- **chore(tests): remove unused test**

Now the command `freeze -execute "lolcat hello.txt" -o 182.png` works... Tested with both png and svg outputs

![182](https://github.com/user-attachments/assets/c2476fae-0892-44a0-97ca-7c5764c6f3e8)
