### PR TITLE
fix: correct default output format and enable pipe output

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ freeze artichoke.hs --theme dracula
 
 ### Output
 
-Change the output file location, defaults to `out.svg` or stdout if piped. This
+Change the output file location, defaults to `freeze.png` or stdout if piped. This
 value supports `.svg`, `.png`, `.webp`.
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/charmbracelet/x/term v0.2.1
 	github.com/charmbracelet/x/xpty v0.1.2
 	github.com/kanrichan/resvg-go v0.0.2-0.20231001163256-63db194ca9f5
-	github.com/mattn/go-isatty v0.0.20
 	github.com/mattn/go-runewidth v0.0.16
 )
 
@@ -40,6 +39,7 @@ require (
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect


### PR DESCRIPTION
### Describe your changes

- Update README to reflect actual default output (freeze.png, not out.svg)
- Fix pipe output functionality as documented, which was completely broken
- Redirect log messages to stderr to avoid polluting piped output

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
