### PR TITLE
fix: load system fonts for CJK and non-ASCII character support

### DIFF
--- a/font/dirs.go
+++ b/font/dirs.go
@@ -1,0 +1,5 @@
+package font
+
+// DefaultFontsDirs contains the default system font directories.
+// This variable is set by platform-specific files (dirs_*.go).
+var DefaultFontsDirs []string

--- a/font/dirs_darwin.go
+++ b/font/dirs_darwin.go
@@ -1,0 +1,20 @@
+//go:build darwin
+
+package font
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func init() {
+	DefaultFontsDirs = []string{
+		"/System/Library/Fonts",
+		"/Library/Fonts",
+	}
+
+	// Only add user font directory if home dir is available
+	if home, err := os.UserHomeDir(); err == nil {
+		DefaultFontsDirs = append(DefaultFontsDirs, filepath.Join(home, "Library/Fonts"))
+	}
+}

--- a/font/dirs_linux.go
+++ b/font/dirs_linux.go
@@ -1,0 +1,25 @@
+//go:build linux
+
+package font
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func init() {
+	DefaultFontsDirs = []string{
+		"/usr/share/fonts",
+		"/usr/local/share/fonts",
+		"/usr/share/X11/fonts/Type1",
+		"/usr/share/X11/fonts/TTF",
+	}
+
+	// Only add user font directories if home dir is available
+	if home, err := os.UserHomeDir(); err == nil {
+		DefaultFontsDirs = append(DefaultFontsDirs,
+			filepath.Join(home, ".fonts"),
+			filepath.Join(home, ".local/share/fonts"),
+		)
+	}
+}

--- a/font/dirs_other.go
+++ b/font/dirs_other.go
@@ -1,0 +1,10 @@
+//go:build !darwin && !linux && !windows
+
+package font
+
+func init() {
+	// No default font directories for this platform.
+	// System fonts will not be loaded automatically.
+	// Users can still use --font.file to specify a custom font.
+	DefaultFontsDirs = nil
+}

--- a/font/dirs_windows.go
+++ b/font/dirs_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package font
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func init() {
+	windir := os.Getenv("WINDIR")
+	if windir == "" {
+		windir = `C:\Windows`
+	}
+	localAppData := os.Getenv("LOCALAPPDATA")
+
+	DefaultFontsDirs = []string{
+		filepath.Join(windir, "Fonts"),
+	}
+
+	// User fonts directory (Windows 10 1809+)
+	if localAppData != "" {
+		DefaultFontsDirs = append(DefaultFontsDirs,
+			filepath.Join(localAppData, "Microsoft", "Windows", "Fonts"))
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds support for loading system fonts when converting SVG to PNG, fixing the issue where CJK (Chinese, Japanese, Korean) and other non-ASCII characters are not rendered correctly in PNG output.

## Changes

- Add platform-specific font directory definitions using build tags:
  - `dirs_darwin.go`: macOS system font directories
  - `dirs_linux.go`: Linux system font directories
  - `dirs_windows.go`: Windows system font directories
  - `dirs_other.go`: fallback for unsupported platforms
- Modify `png.go` to load fonts from system directories
- Add `FREEZE_NO_SYSTEM_FONTS=1` env var to skip system font loading for performance
- Warn when font directories fail to load (visible at default log level)
- Handle `os.UserHomeDir()` errors properly to avoid relative path issues

## Performance Note

Font directories are scanned on each conversion. For better performance:
- Set `FREEZE_NO_SYSTEM_FONTS=1` to disable system font loading
- Use SVG output instead of PNG
- Install `rsvg-convert` (which handles fonts natively)

## Testing

- [x] Tested cross-platform compilation (darwin, linux, windows, freebsd)
- [x] Tested PNG output with CJK characters on macOS

## Related Issues

Fixes #93
Related to #83 (this PR follows the maintainer suggestion to use build tags instead of runtime checks)