### PR TITLE
expand --output path so '~' and relative paths land where users expect

### DIFF
--- a/main.go
+++ b/main.go
@@ -132,6 +132,11 @@ func main() {
 	if config.Output == "" {
 		config.Output = defaultOutputFilename
 	}
+	if expanded, err := expandPath(config.Output); err == nil {
+		config.Output = expanded
+	} else {
+		printErrorFatal("Unable to resolve output path", err)
+	}
 
 	scale = 1
 	if autoHeight && autoWidth && strings.HasSuffix(config.Output, ".png") {
@@ -453,4 +458,23 @@ var outputHeader = lipgloss.NewStyle().Foreground(lipgloss.Color("#F1F1F1")).Bac
 
 func printFilenameOutput(filename string) {
 	fmt.Println(lipgloss.JoinHorizontal(lipgloss.Center, outputHeader.String(), filename))
+}
+
+// expandPath replaces a leading "~" with the user's home directory and turns
+// the result into an absolute path. rsvg-convert and os.WriteFile both treat
+// "~" literally, so without this an output like "~/out.png" lands in a file
+// named "~" rather than under $HOME.
+func expandPath(p string) (string, error) {
+	if p == "~" || strings.HasPrefix(p, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		if p == "~" {
+			p = home
+		} else {
+			p = filepath.Join(home, p[2:])
+		}
+	}
+	return filepath.Abs(p)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExpandPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("no home dir available: %v", err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"tilde alone", "~", home},
+		{"tilde slash file", "~/out.png", filepath.Join(home, "out.png")},
+		{"tilde slash nested", "~/Pictures/out.png", filepath.Join(home, "Pictures", "out.png")},
+		{"relative file", "out.png", filepath.Join(cwd, "out.png")},
+		{"relative parent", "../out.png", filepath.Clean(filepath.Join(cwd, "..", "out.png"))},
+		{"absolute file", "/tmp/out.png", "/tmp/out.png"},
+		{"tilde in middle is left alone", "foo/~/bar", filepath.Join(cwd, "foo/~/bar")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := expandPath(tc.in)
+			if err != nil {
+				t.Fatalf("expandPath(%q) returned err: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("expandPath(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			if strings.Contains(got, "~") && !strings.Contains(tc.in[1:], "~") {
+				t.Errorf("result still contains ~: %q", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #222.

`rsvg-convert` and `os.WriteFile` both treat `~` as a literal character, so `freeze ... -o ~/out.png` either errors out or writes a file called `~` in the working directory instead of dropping the PNG in `\$HOME`. Same kind of surprise with bare relative paths when freeze is invoked from a script that chdirs around.

Added an `expandPath` helper that swaps a leading `~` or `~/` for the user's home directory and calls `filepath.Abs` on the result. Runs once on `config.Output` right after the default filename is applied, so every downstream code path (libsvg, resvg, `doc.WriteToFile`) sees the final absolute path.

Unit test covers the cases you'd expect: bare `~`, `~/file`, `~/nested/file`, plain relative, `..`, absolute, and a `~` that isn't at the start (left alone).