### PR TITLE
help: swap JoinHorizontal/JoinVertical position arguments

### DIFF
--- a/help.go
+++ b/help.go
@@ -29,9 +29,9 @@ func helpPrinter(_ kong.HelpOptions, ctx *kong.Context) error {
 	fmt.Println(
 		codeBlockStyle.Render(
 			lipgloss.JoinVertical(
-				lipgloss.Top,
-				lipgloss.JoinHorizontal(lipgloss.Left, programStyle.Render("freeze"), argumentStyle.Render("main.go"), flagStyle.Render("[-o code.svg] [--flags]")),
-				lipgloss.JoinHorizontal(lipgloss.Left, programStyle.Render("freeze"), argumentStyle.Render("--execute"), stringStyle.Render("\"ls -la\""), flagStyle.Render("[--flags]   ")),
+				lipgloss.Left,
+				lipgloss.JoinHorizontal(lipgloss.Top, programStyle.Render("freeze"), argumentStyle.Render("main.go"), flagStyle.Render("[-o code.svg] [--flags]")),
+				lipgloss.JoinHorizontal(lipgloss.Top, programStyle.Render("freeze"), argumentStyle.Render("--execute"), stringStyle.Render("\"ls -la\""), flagStyle.Render("[--flags]   ")),
 			),
 		),
 	)


### PR DESCRIPTION
Closes #116.

\`JoinVertical\`'s position is horizontal alignment (Left/Center/Right) and \`JoinHorizontal\`'s is vertical alignment (Top/Center/Bottom). The help output had them reversed: \`JoinVertical\` was given \`Top\` and the inner \`JoinHorizontal\` calls were given \`Left\`. The output happens to look fine today because the joined cells are single-row, but the args don't match what the functions expect.