### PR TITLE
feat: load user config by default when available

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,6 +96,12 @@ func main() {
 	if config.Config == "user" {
 		configFile, err = loadUserConfig()
 	}
+	// when using the default config, prefer the user config if it exists
+	if isDefaultConfig {
+		if uf, userErr := loadUserConfig(); userErr == nil {
+			configFile = uf
+		}
+	}
 	if err != nil {
 		configFile, err = os.Open(config.Config)
 	}


### PR DESCRIPTION
## What

When `--config` is not explicitly set (the default), the user config at `~/.config/freeze/user.json` is now loaded automatically if it exists. This removes the need to pass `-c user` every time.

If no user config exists, the embedded default config is used as before — fully backward compatible.

## Why

Fixes #90. Currently users must pass `-c user` on every invocation to use their saved config. This makes the user config the implicit default when present.

## How

Added a 6-line check after the initial config load: if using the default config and a user config file exists, prefer it.

## Testing

`go test ./...` passes. The change is guarded by `loadUserConfig()` returning an error when no user config exists, preserving existing behavior.