### PR TITLE
fix(interactive): restrict font family to embedded fonts

### DIFF
--- a/interactive.go
+++ b/interactive.go
@@ -14,10 +14,42 @@ import (
 
 var green = lipgloss.Color("#03BF87")
 
+const (
+	embeddedFontJetBrainsMono   = "JetBrains Mono"
+	embeddedFontJetBrainsMonoNL = "JetBrains Mono NL"
+)
+
+var embeddedFontFamilies = []string{
+	embeddedFontJetBrainsMono,
+	embeddedFontJetBrainsMonoNL,
+}
+
+func embeddedFontFamilySelection(config *Config) string {
+	if !config.Font.Ligatures {
+		return embeddedFontJetBrainsMonoNL
+	}
+	return embeddedFontJetBrainsMono
+}
+
+func applyEmbeddedFontFamily(selection string, config *Config) {
+	switch selection {
+	case embeddedFontJetBrainsMonoNL:
+		config.Font.Family = embeddedFontJetBrainsMono
+		config.Font.Ligatures = false
+	case embeddedFontJetBrainsMono:
+		config.Font.Family = embeddedFontJetBrainsMono
+		config.Font.Ligatures = true
+	default:
+		config.Font.Family = embeddedFontJetBrainsMono
+		config.Font.Ligatures = true
+	}
+}
+
 func runForm(config *Config) (*Config, error) {
 	var (
 		padding      = strings.Trim(fmt.Sprintf("%v", config.Padding), "[]")
 		margin       = strings.Trim(fmt.Sprintf("%v", config.Margin), "[]")
+		fontFamily   = embeddedFontFamilySelection(config)
 		fontSize     = fmt.Sprintf("%d", int(config.Font.Size))
 		lineHeight   = fmt.Sprintf("%.1f", config.LineHeight)
 		borderRadius = fmt.Sprintf("%.0f", config.Border.Radius)
@@ -105,12 +137,11 @@ func runForm(config *Config) (*Config, error) {
 
 			huh.NewNote().Title("Font"),
 
-			huh.NewInput().Title("Font Family ").
+			huh.NewSelect[string]().Title("Font Family ").
 				// Description("Font family to use for code").
-				Placeholder("JetBrains Mono").
 				Inline(true).
-				Prompt("").
-				Value(&config.Font.Family),
+				Options(huh.NewOptions(embeddedFontFamilies...)...).
+				Value(&fontFamily),
 
 			huh.NewInput().Title("Font Size ").
 				// Description("Font size to use for code.").
@@ -190,6 +221,7 @@ func runForm(config *Config) (*Config, error) {
 
 	config.Padding = parsePadding(padding)
 	config.Margin = parseMargin(margin)
+	applyEmbeddedFontFamily(fontFamily, config)
 	config.Font.Size, _ = strconv.ParseFloat(fontSize, 64)
 	config.LineHeight, _ = strconv.ParseFloat(lineHeight, 64)
 	config.Border.Radius, _ = strconv.ParseFloat(borderRadius, 64)

--- a/interactive_test.go
+++ b/interactive_test.go
@@ -1,0 +1,89 @@
+package main
+
+import "testing"
+
+func TestEmbeddedFontFamilySelection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		ligatures bool
+		want      string
+	}{
+		{
+			name:      "ligatures enabled",
+			ligatures: true,
+			want:      embeddedFontJetBrainsMono,
+		},
+		{
+			name:      "ligatures disabled",
+			ligatures: false,
+			want:      embeddedFontJetBrainsMonoNL,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			config := &Config{
+				Font: Font{Ligatures: tt.ligatures},
+			}
+			if got := embeddedFontFamilySelection(config); got != tt.want {
+				t.Fatalf("embeddedFontFamilySelection() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyEmbeddedFontFamily(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		selection string
+		want      Font
+	}{
+		{
+			name:      "jetbrains mono",
+			selection: embeddedFontJetBrainsMono,
+			want: Font{
+				Family:    embeddedFontJetBrainsMono,
+				Ligatures: true,
+			},
+		},
+		{
+			name:      "jetbrains mono nl",
+			selection: embeddedFontJetBrainsMonoNL,
+			want: Font{
+				Family:    embeddedFontJetBrainsMono,
+				Ligatures: false,
+			},
+		},
+		{
+			name:      "unknown selection defaults to mono",
+			selection: "Fira Code",
+			want: Font{
+				Family:    embeddedFontJetBrainsMono,
+				Ligatures: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			config := &Config{
+				Font: Font{
+					Family:    "custom",
+					Ligatures: false,
+				},
+			}
+			applyEmbeddedFontFamily(tt.selection, config)
+			if config.Font != tt.want {
+				t.Fatalf("applyEmbeddedFontFamily() = %+v, want %+v", config.Font, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Replace the free-text font family field in interactive mode with a select control limited to the two embedded fonts: JetBrains Mono and JetBrains Mono NL.

## Motivation

Typing an unavailable font name (e.g. Fira Code, Monaco) in interactive mode produced output with no visible text because only JetBrains Mono variants are embedded in the binary. The theme field already uses `huh.NewSelect` to constrain choices; the font family field should follow the same pattern.

Fixes #272

## Changes

- Add `embeddedFontFamilySelection` and `applyEmbeddedFontFamily` helpers to map UI selection to `Font.Family` and `Font.Ligatures`
- Replace `huh.NewInput` with `huh.NewSelect` for the font family field
- Map "JetBrains Mono NL" to `Family="JetBrains Mono"` with `Ligatures=false`, matching existing `fontOptions` embedding logic
- Add unit tests for the helper functions

## Tests

- `go test ./...` — pass
- `go vet ./...` — pass

## Notes

- Interactive mode now only supports the two embedded fonts. CLI `--font.family` and `--font.file` for custom fonts are unchanged.
- Custom font files via `--font.file` remain a CLI-only option for advanced use, as suggested in the issue.