### PR TITLE
fix: custom fonts not used in PNG output

### DIFF
--- a/font_darwin.go
+++ b/font_darwin.go
@@ -1,0 +1,15 @@
+package main
+
+import "os"
+
+func systemFontDirs() []string {
+	dirs := []string{
+		"/System/Library/Fonts",
+		"/System/Library/Fonts/Supplemental",
+		"/Library/Fonts",
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, home+"/Library/Fonts")
+	}
+	return dirs
+}

--- a/font_linux.go
+++ b/font_linux.go
@@ -1,0 +1,14 @@
+package main
+
+import "os"
+
+func systemFontDirs() []string {
+	dirs := []string{
+		"/usr/share/fonts",
+		"/usr/local/share/fonts",
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, home+"/.local/share/fonts", home+"/.fonts")
+	}
+	return dirs
+}

--- a/font_windows.go
+++ b/font_windows.go
@@ -1,0 +1,16 @@
+package main
+
+import "os"
+
+func systemFontDirs() []string {
+	var dirs []string
+	if windir := os.Getenv("WINDIR"); windir != "" {
+		dirs = append(dirs, windir+`\Fonts`)
+	} else {
+		dirs = append(dirs, `C:\Windows\Fonts`)
+	}
+	if localAppData := os.Getenv("LOCALAPPDATA"); localAppData != "" {
+		dirs = append(dirs, localAppData+`\Microsoft\Windows\Fonts`)
+	}
+	return dirs
+}

--- a/main.go
+++ b/main.go
@@ -404,7 +404,7 @@ func main() {
 		}
 
 		// could not convert with libsvg, try resvg
-		svgConversionErr = resvgConvert(doc, imageWidth, imageHeight, config.Output)
+		svgConversionErr = resvgConvert(doc, imageWidth, imageHeight, config.Output, &config)
 		if svgConversionErr != nil {
 			printErrorFatal("Unable to convert SVG to PNG", svgConversionErr)
 		}

--- a/png.go
+++ b/png.go
@@ -3,8 +3,10 @@ package main
 import (
 	"bytes"
 	"context"
+	"io/fs"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/beevik/etree"
 	"github.com/charmbracelet/freeze/font"
@@ -30,7 +32,7 @@ func libsvgConvert(doc *etree.Document, _, _ float64, output string) error {
 	return err //nolint: wrapcheck
 }
 
-func resvgConvert(doc *etree.Document, w, h float64, output string) error {
+func resvgConvert(doc *etree.Document, w, h float64, output string, config *Config) error {
 	svg, err := doc.WriteToBytes()
 	if err != nil {
 		return err //nolint: wrapcheck
@@ -47,6 +49,41 @@ func resvgConvert(doc *etree.Document, w, h float64, output string) error {
 		printErrorFatal("Unable to write output", err)
 	}
 	defer fontdb.Close() //nolint: errcheck
+
+	// resvg's wasm sandbox cannot open arbitrary host paths, so we must read
+	// font files on the host and pass the bytes through.
+	if config != nil && config.Font.File != "" {
+		bts, err := os.ReadFile(config.Font.File)
+		if err != nil {
+			printErrorFatal("Unable to load font", err)
+		}
+		if err := fontdb.LoadFontData(bts); err != nil {
+			printErrorFatal("Unable to load font", err)
+		}
+	}
+
+	// Load system fonts so a user-specified --font.family can resolve.
+	// We walk on the host and feed bytes via LoadFontData, since the wasm
+	// sandbox blocks direct filesystem access. Errors are intentionally
+	// ignored: unreadable files and missing directories are skipped.
+	for _, dir := range systemFontDirs() {
+		_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil //nolint:nilerr
+			}
+			ext := filepath.Ext(path)
+			if ext != ".ttf" && ext != ".otf" && ext != ".ttc" {
+				return nil
+			}
+			bts, err := os.ReadFile(path) //nolint:gosec
+			if err != nil {
+				return nil //nolint:nilerr
+			}
+			_ = fontdb.LoadFontData(bts)
+			return nil
+		})
+	}
+
 	err = fontdb.LoadFontData(font.JetBrainsMonoTTF)
 	if err != nil {
 		printErrorFatal("Unable to load font", err)
@@ -63,8 +100,14 @@ func resvgConvert(doc *etree.Document, w, h float64, output string) error {
 	}
 	defer pixmap.Close() //nolint: errcheck
 
+	fontFamily := "JetBrains Mono"
+	if config != nil && config.Font.Family != "" {
+		fontFamily = config.Font.Family
+	}
+
 	tree, err := worker.NewTreeFromData(svg, &resvg.Options{
 		Dpi:                192,
+		FontFamily:         fontFamily,
 		ShapeRenderingMode: resvg.ShapeRenderingModeGeometricPrecision,
 		TextRenderingMode:  resvg.TextRenderingModeOptimizeLegibility,
 		ImageRenderingMode: resvg.ImageRenderingModeOptimizeQuality,


### PR DESCRIPTION
## What?

PNG images now use the font you pick. Before, they always fell back to the built-in font.

## Why?

When you told freeze to use a font like "Input Mono Condensed" for a PNG, it quietly ignored your choice and used JetBrains Mono instead. SVGs worked fine, but PNGs went through a different renderer that couldn't see any of your computer's fonts. Now it can, so  `—font.family` and `--font.file` work the same for PNG as they already did for SVG.

Fixes #273 